### PR TITLE
Updating model's config instead of assigning

### DIFF
--- a/flask_pynamodb/__init__.py
+++ b/flask_pynamodb/__init__.py
@@ -58,9 +58,9 @@ class PynamoDB:
         if not app or not isinstance(app, Flask):
             raise TypeError("Invalid Flask app instance.")
 
-        self.Model._app_config = {
-            self._convert_key(k): v for k, v in app.config.items() if k in DYNAMODB_SETTINGS
-        }
+        self.Model._app_config.update(
+            {self._convert_key(k): v for k, v in app.config.items() if k in DYNAMODB_SETTINGS}
+        )
 
         connection = self._create_connection(self.Model._app_config)
         app.extensions["pynamodb"] = {"db": self, "connection": connection}


### PR DESCRIPTION
## Current Behavior

When calling `init_app` multiple times, the model's base metadata (stored in `_app_config`) would be completely overridden.
Although we do not support multiple base models for each app, we should prefer updating the configuration rather than override it.

## New Behavior

If `init_app` is called multiple times, the model's base metadata would be merged to the last base metadata.